### PR TITLE
Encode language name in GitHub URL

### DIFF
--- a/src/app/component/animatedbar.tsx
+++ b/src/app/component/animatedbar.tsx
@@ -41,7 +41,7 @@ export function AnimatedBar({
       }}
       href={
         username !== undefined && !loading && language
-          ? `https://github.com/${username}?tab=repositories&q=&type=&language=${language.name}`
+          ? `https://github.com/${username}?tab=repositories&q=&type=&language=${encodeURIComponent(language.name)}`
           : undefined
       }
       target="_blank"


### PR DESCRIPTION
This fixes an issue with the language C# as the hash isn't encoded properly and leads to results about the language C